### PR TITLE
Lazy tests

### DIFF
--- a/bin/chef-foodcritic-publisher.sh
+++ b/bin/chef-foodcritic-publisher.sh
@@ -21,7 +21,11 @@ then
     . "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
 fi
 
-for cbname in `find cookbooks -maxdepth 1 -mindepth 1 -type d | sed -e 's/cookbooks\///'`; do
+GIT_PREVIOUS_COMMIT=${1}
+GIT_COMMIT=${2}
+
+# Gets the cookbook names from the git diff
+for cbname in `git diff --name-only ${GIT_PREVIOUS_COMMIT} ${GIT_COMMIT} | awk '$1 ~ /^cookbooks/' | sed -e 's/cookbooks\///' | awk -F '[/]' '{print $1}' | uniq`; do
   echo "------ foodcritic checks: $cbname ------"
   $FOODCRITIC $@ cookbooks/$cbname | chef-ci-tools/bin/foodcritic2junit.pl --suite $cbname --out junit_reports/foodcritic-$cbname.xml
 done

--- a/bin/chef-foodcritic-publisher.sh
+++ b/bin/chef-foodcritic-publisher.sh
@@ -15,7 +15,7 @@ fi
 rm junit_reports/foodcritic-*.xml 2>/dev/null
 
 PATH=${HOME}/bin:${PATH}
-
+FOODCRITIC=${FOODCRITIC:-foodcritic}
 if [ -s ${HOME}/.rvm/scripts/rvm ]
 then
     . "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
@@ -23,5 +23,5 @@ fi
 
 for cbname in `find cookbooks -maxdepth 1 -mindepth 1 -type d | sed -e 's/cookbooks\///'`; do
   echo "------ foodcritic checks: $cbname ------"
-  foodcritic $@ cookbooks/$cbname | chef-ci-tools/bin/foodcritic2junit.pl --suite $cbname --out junit_reports/foodcritic-$cbname.xml
+  $FOODCRITIC $@ cookbooks/$cbname | chef-ci-tools/bin/foodcritic2junit.pl --suite $cbname --out junit_reports/foodcritic-$cbname.xml
 done

--- a/bin/foodcritic2junit.pl
+++ b/bin/foodcritic2junit.pl
@@ -26,12 +26,8 @@ use Getopt::Long;
 #------------------------------------------------------------#
 
 my $FOODCRITIC_RULE_COUNT = 45;
-my @DEPRECATED_RULES = ( 1, 20, 35);
 my %MESSAGES_BY_RULE = (); # autopopulate as needed
 my %VIOLATIONS_BY_RULE = map { sprintf('FC%03d', $_) => [] } (1..$FOODCRITIC_RULE_COUNT);
-for (@DEPRECATED_RULES) {
-    delete $VIOLATIONS_BY_RULE{sprintf('FC%03d', $_)};
-}
 
 # print join("\n", sort keys %VIOLATIONS_BY_RULE);
 


### PR DESCRIPTION
### What does it do?

The change implement a 'lazy' test running for foodcritic. From now on foodcritic will only be run on those cookbooks that have changed since the last jenkins build. This enables smarter email notifications where only those people will get email notifications who really broke foodcritic with their changes.

To be merged together with this [pull request](https://github.com/prezi/prezi-chef/pull/396).
### Known limitation

People who are working on the same cookbook may miss email notifications as only the last commit's author will be notified. In edge cases it can mean that you don't get a recovery email about a change that fixed the broken foodcritic rule.
